### PR TITLE
Support directory parsing for AST generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ See [SRS.md](SRS.md) for the software requirements collected from GitHub issues.
 After installing the dependencies (`pip install clang==17.* graphviz` and a system `graphviz` package), run:
 
 ```bash
-./generate_ast_image.py <source_file.c> -o output.png
+./generate_ast_image.py <source_or_directory> -o output.png
 ```
 
-The script parses the source file using `libclang` and outputs the AST as a PNG image.
+The script parses the given file or all C/C++ files inside a directory using `libclang` and outputs the AST as a PNG image.
 
 On Windows, install LLVM and ensure `libclang.dll` is available. You can provide
 the path explicitly using `--clang-lib` or set the environment variable

--- a/cpp_ast_codex/__init__.py
+++ b/cpp_ast_codex/__init__.py
@@ -1,0 +1,15 @@
+from .ast_builder import (
+    ASTNode,
+    parse_source,
+    parse_file,
+    parse_directory,
+    parse_path,
+)
+
+__all__ = [
+    "ASTNode",
+    "parse_source",
+    "parse_file",
+    "parse_directory",
+    "parse_path",
+]

--- a/cpp_ast_codex/ast_builder.py
+++ b/cpp_ast_codex/ast_builder.py
@@ -2,7 +2,8 @@ import os
 import clang.cindex
 from ctypes.util import find_library
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
+from pathlib import Path
 
 @dataclass
 class ASTNode:
@@ -47,3 +48,30 @@ def parse_source(code: str, filename: str = "tmp.c", *, clang_lib: Optional[str]
     index = clang.cindex.Index.create()
     tu = index.parse(filename, args=clang_args, unsaved_files=[(filename, code)], options=0)
     return _create_node(tu.cursor)
+
+
+def parse_file(path: Union[str, Path], *, clang_lib: Optional[str] = None, clang_args: Optional[List[str]] = None) -> ASTNode:
+    """Parse a single file on disk and return its AST."""
+    path = Path(path)
+    code = path.read_text()
+    return parse_source(code, filename=str(path), clang_lib=clang_lib, clang_args=clang_args)
+
+
+def parse_directory(path: Union[str, Path], *, clang_lib: Optional[str] = None, clang_args: Optional[List[str]] = None) -> ASTNode:
+    """Parse all C/C++ source files inside ``path`` and return a combined AST."""
+    directory = Path(path)
+    root = ASTNode(kind="DIRECTORY", spelling=str(directory))
+    for file in sorted(directory.rglob("*")):
+        if file.suffix.lower() in {".c", ".cc", ".cpp", ".cxx", ".h", ".hpp", ".hh", ".hxx"} and file.is_file():
+            root.children.append(parse_file(file, clang_lib=clang_lib, clang_args=clang_args))
+    return root
+
+
+def parse_path(path: Union[str, Path], *, clang_lib: Optional[str] = None, clang_args: Optional[List[str]] = None) -> ASTNode:
+    """Parse a single file or directory and return an AST."""
+    p = Path(path)
+    if p.is_dir():
+        return parse_directory(p, clang_lib=clang_lib, clang_args=clang_args)
+    if p.is_file():
+        return parse_file(p, clang_lib=clang_lib, clang_args=clang_args)
+    raise FileNotFoundError(path)

--- a/generate_ast_image.py
+++ b/generate_ast_image.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python3
 import argparse
-from pathlib import Path
 
-from cpp_ast_codex.ast_builder import parse_source
+from cpp_ast_codex.ast_builder import parse_path
 from cpp_ast_codex.visualize import to_graph
 
 DEFAULT_CLANG = None
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate AST image from C/C++ source file')
-    parser.add_argument('source', help='Path to C/C++ source file')
+    parser = argparse.ArgumentParser(description='Generate AST image from C/C++ source file or directory')
+    parser.add_argument('source', help='Path to C/C++ source file or directory')
     parser.add_argument('-o', '--output', default='ast.png', help='Output image path (PNG)')
     parser.add_argument('--clang-lib', default=DEFAULT_CLANG, help='Path to libclang shared library (optional)')
     parser.add_argument('--clang-args', nargs='*', default=['-std=c++17'], help='Extra arguments for clang parser')
     args = parser.parse_args()
 
-    code = Path(args.source).read_text()
-    root = parse_source(code, filename=str(args.source), clang_lib=args.clang_lib, clang_args=args.clang_args)
+    root = parse_path(args.source, clang_lib=args.clang_lib, clang_args=args.clang_args)
     graph = to_graph(root)
     graph.format = 'png'
     graph.render(filename=args.output, cleanup=True)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,5 +1,5 @@
 import os
-from cpp_ast_codex.ast_builder import parse_source
+from cpp_ast_codex.ast_builder import parse_source, parse_path
 from cpp_ast_codex.visualize import to_graph
 
 SAMPLE_CODE = """\
@@ -25,4 +25,15 @@ def test_graph_generation(tmp_path):
     graph.format = 'png'
     graph.render(filename=str(output), cleanup=True)
     assert os.path.exists(str(output) + '.png')
+
+
+def test_parse_directory(tmp_path):
+    file1 = tmp_path / "a.cpp"
+    file2 = tmp_path / "b.cpp"
+    file1.write_text("int a(){return 1;}")
+    file2.write_text("int b(){return 2;}")
+    root = parse_path(tmp_path)
+    kinds = [child.kind for child in root.children]
+    assert root.kind == "DIRECTORY"
+    assert "TRANSLATION_UNIT" in kinds
 


### PR DESCRIPTION
## Summary
- support parsing directories of source code
- expose new helper functions in package
- update CLI to accept file or directory path
- document directory usage in README
- test directory parsing logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e9f493c08330b2b1cac491a52af1