### PR TITLE
Add textual AST output feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ After installing the dependencies (`pip install clang==17.* graphviz` and a syst
 
 ```bash
 ./generate_ast_image.py <source_or_directory> -o output.png
+./print_ast.py <source_or_directory>
 ```
 
 The script parses the given file or all C/C++ files inside a directory using `libclang` and outputs the AST as a PNG image.
+`print_ast.py` prints the AST in a textual tree format similar to the `tree` command.
+
+See [docs/text_output.md](docs/text_output.md) for more details on the text output format.
 
 On Windows, install LLVM and ensure `libclang.dll` is available. You can provide
 the path explicitly using `--clang-lib` or set the environment variable

--- a/cpp_ast_codex/__init__.py
+++ b/cpp_ast_codex/__init__.py
@@ -5,6 +5,7 @@ from .ast_builder import (
     parse_directory,
     parse_path,
 )
+from .text import to_text
 
 __all__ = [
     "ASTNode",
@@ -12,4 +13,5 @@ __all__ = [
     "parse_file",
     "parse_directory",
     "parse_path",
+    "to_text",
 ]

--- a/cpp_ast_codex/text.py
+++ b/cpp_ast_codex/text.py
@@ -1,0 +1,16 @@
+from .ast_builder import ASTNode
+
+
+def _to_lines(node: ASTNode, prefix: str, is_last: bool) -> list[str]:
+    connector = "└── " if is_last else "├── "
+    line = f"{prefix}{connector}{node.kind}: {node.spelling}".rstrip()
+    lines = [line]
+    child_prefix = prefix + ("    " if is_last else "│   ")
+    for i, child in enumerate(node.children):
+        lines.extend(_to_lines(child, child_prefix, i == len(node.children) - 1))
+    return lines
+
+
+def to_text(node: ASTNode) -> str:
+    """Return a textual tree representation of the AST."""
+    return "\n".join(_to_lines(node, prefix="", is_last=True))

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,6 +9,8 @@
   - `parse_source`, `parse_file`, `parse_directory`, `parse_path` 함수: libclang을 이용해 소스코드 또는 디렉터리를 파싱하여 `ASTNode` 트리로 변환한다.
 - **시각화 모듈** (`cpp_ast_codex/visualize.py`)
   - `to_graph` 함수: `ASTNode` 트리를 Graphviz `Digraph` 객체로 변환한다.
+- **텍스트 출력 모듈** (`cpp_ast_codex/text.py`)
+  - `to_text` 함수: `ASTNode` 트리를 텍스트 형태로 표현한다.
 - **명령줄 도구** (`generate_ast_image.py`)
   - 입력 경로와 출력 파일명을 받아 AST 이미지를 생성한다.
 
@@ -39,14 +41,19 @@ classDiagram
     class visualize {
         +to_graph(node)
     }
+    class text {
+        +to_text(node)
+    }
     class CLI {
         +main()
     }
 
     ast_builder --> ASTNode
     visualize --> ASTNode
+    text --> ASTNode
     CLI --> ast_builder : parse_path
     CLI --> visualize : to_graph
+    CLI --> text : to_text
 ```
 
 위 구조를 바탕으로 세부 기능을 확장하며 구현을 진행한다.

--- a/docs/text_output.md
+++ b/docs/text_output.md
@@ -1,0 +1,17 @@
+# Text Output Module
+
+`cpp_ast_codex/text.py` provides a simple textual tree representation of the AST produced by `ast_builder`.
+
+```
+└── TRANSLATION_UNIT: sample.cpp
+    ├── FUNCTION_DECL: add
+    │   └── COMPOUND_STMT:
+    │       └── RETURN_STMT:
+    └── FUNCTION_DECL: main
+```
+
+Use the `print_ast.py` script to generate this view from the command line:
+
+```bash
+./print_ast.py samples/hello.cpp
+```

--- a/print_ast.py
+++ b/print_ast.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import argparse
+
+from cpp_ast_codex.ast_builder import parse_path
+from cpp_ast_codex.text import to_text
+
+DEFAULT_CLANG = None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Print AST as text for a C/C++ source file or directory')
+    parser.add_argument('source', help='Path to C/C++ source file or directory')
+    parser.add_argument('--clang-lib', default=DEFAULT_CLANG, help='Path to libclang shared library (optional)')
+    parser.add_argument('--clang-args', nargs='*', default=['-std=c++17'], help='Extra arguments for clang parser')
+    args = parser.parse_args()
+
+    root = parse_path(args.source, clang_lib=args.clang_lib, clang_args=args.clang_args)
+    print(to_text(root))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,6 +1,7 @@
 import os
 from cpp_ast_codex.ast_builder import parse_source, parse_path
 from cpp_ast_codex.visualize import to_graph
+from cpp_ast_codex.text import to_text
 
 SAMPLE_CODE = """\
 int add(int a, int b) {
@@ -36,4 +37,11 @@ def test_parse_directory(tmp_path):
     kinds = [child.kind for child in root.children]
     assert root.kind == "DIRECTORY"
     assert "TRANSLATION_UNIT" in kinds
+
+
+def test_text_output():
+    root = parse_source(SAMPLE_CODE, filename="sample.cpp")
+    text = to_text(root)
+    assert "TRANSLATION_UNIT" in text
+    assert "FUNCTION_DECL" in text
 


### PR DESCRIPTION
## Summary
- provide `to_text` for textual AST view
- expose the new function in package exports
- add `print_ast.py` CLI script and document usage
- update design docs with text module
- include unit tests for text output

## Testing
- `CLANG_LIBRARY_FILE=/lib/x86_64-linux-gnu/libclang-19.so.19 PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f97d514c83308bd91d47dbb751f2